### PR TITLE
fix: Add missing change.actions values to planfile.ts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30162,9 +30162,11 @@ var planfileSchema = z.object({
         actions: z.union([
           z.tuple([z.literal("no-op")]),
           z.tuple([z.literal("create")]),
+          z.tuple([z.literal("read")]),
           z.tuple([z.literal("delete")]),
           z.tuple([z.literal("update")]),
-          z.tuple([z.literal("delete"), z.literal("create")])
+          z.tuple([z.literal("delete"), z.literal("create")]),
+          z.tuple([z.literal("create"), z.literal("delete")])
         ])
       })
     })
@@ -30238,7 +30240,9 @@ function internalRenderPlan(structuredPlan, humanReadablePlan) {
   }
   const createdResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["create"].toString()).map((r) => r.address);
   const updatedResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["update"].toString()).map((r) => r.address);
-  const recreatedResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["delete", "create"].toString()).map((r) => r.address);
+  const recreatedResources = structuredPlan.resource_changes.filter(
+    (r) => r.change.actions.toString() === ["delete", "create"].toString() || r.change.actions.toString() === ["create", "delete"].toString()
+  ).map((r) => r.address);
   const deletedResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["delete"].toString()).map((r) => r.address);
   return {
     createdResources: extractResources(createdResources, humanReadablePlan),

--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -18,9 +18,11 @@ const planfileSchema = z.object({
         actions: z.union([
           z.tuple([z.literal('no-op')]),
           z.tuple([z.literal('create')]),
+          z.tuple([z.literal('read')]),
           z.tuple([z.literal('delete')]),
           z.tuple([z.literal('update')]),
           z.tuple([z.literal('delete'), z.literal('create')])
+          z.tuple([z.literal('create'), z.literal('delete')])
         ])
       })
     })

--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -21,7 +21,7 @@ const planfileSchema = z.object({
           z.tuple([z.literal('read')]),
           z.tuple([z.literal('delete')]),
           z.tuple([z.literal('update')]),
-          z.tuple([z.literal('delete'), z.literal('create')])
+          z.tuple([z.literal('delete'), z.literal('create')]),
           z.tuple([z.literal('create'), z.literal('delete')])
         ])
       })

--- a/src/render.ts
+++ b/src/render.ts
@@ -108,7 +108,11 @@ export function internalRenderPlan(
     .filter((r) => r.change.actions.toString() === ['update'].toString())
     .map((r) => r.address)
   const recreatedResources = structuredPlan.resource_changes
-    .filter((r) => r.change.actions.toString() === ['delete', 'create'].toString())
+    .filter(
+      (r) =>
+        r.change.actions.toString() === ['delete', 'create'].toString() ||
+        r.change.actions.toString() === ['create', 'delete'].toString()
+    )
     .map((r) => r.address)
   const deletedResources = structuredPlan.resource_changes
     .filter((r) => r.change.actions.toString() === ['delete'].toString())


### PR DESCRIPTION
https://developer.hashicorp.com/terraform/internals/json-format#change-representation has two entries in change.actions that aren't currently in the definition for planfileSchema: ['read'] and ['create', 'delete'].

I've done very little Typescript work, but It looks like these are pretty simple to add, so I've made this PR to include them.


# Motivation

I'm looking for a currently-maintained Github action to comment with summaries of `terraform plan` results on my team's PRs, and this one looks really nicely done.

I tried out this action with a change to one of my team's Terraform definitions, and while the code coped fine with a plan without changes, it errored on the first change entry, which had an action of `"read"`.

<details>
<summary>The error output from Zod</summary>

```json
[
  {
    "code": "invalid_union",
    "unionErrors": [
      {
        "issues": [
          {
            "received": "read",
            "code": "invalid_literal",
            "expected": "no-op",
            "path": [
              "resource_changes",
              0,
              "change",
              "actions",
              0
            ],
            "message": "Invalid literal value, expected \"no-op\""
          }
        ],
        "name": "ZodError"
      },
      {
        "issues": [
          {
            "received": "read",
            "code": "invalid_literal",
            "expected": "create",
            "path": [
              "resource_changes",
              0,
              "change",
              "actions",
              0
            ],
            "message": "Invalid literal value, expected \"create\""
          }
        ],
        "name": "ZodError"
      },
      {
        "issues": [
          {
            "received": "read",
            "code": "invalid_literal",
            "expected": "delete",
            "path": [
              "resource_changes",
              0,
              "change",
              "actions",
              0
            ],
            "message": "Invalid literal value, expected \"delete\""
          }
        ],
        "name": "ZodError"
      },
      {
        "issues": [
          {
            "received": "read",
            "code": "invalid_literal",
            "expected": "update",
            "path": [
              "resource_changes",
              0,
              "change",
              "actions",
              0
            ],
            "message": "Invalid literal value, expected \"update\""
          }
        ],
        "name": "ZodError"
      },
      {
        "issues": [
          {
            "code": "too_small",
            "minimum": 2,
            "inclusive": true,
            "exact": false,
            "type": "array",
            "path": [
              "resource_changes",
              0,
              "change",
              "actions"
            ],
            "message": "Array must contain at least 2 element(s)"
          }
        ],
        "name": "ZodError"
      }
    ],
    "path": [
      "resource_changes",
      0,
      "change",
      "actions"
    ],
    "message": "Invalid input"
  }
]
```

</details>

# Changes

Adding the two possible entries for `changes.actions` that are in [the current JSON output change representation](https://developer.hashicorp.com/terraform/internals/json-format#change-representation) but not in here yet.
