### PR TITLE
refactor!: Replace `id` input with more general `header` parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,6 @@ exclude: ^dist/
 repos:
   - repo: local
     hooks:
-      - id: build
-        name: build
-        entry: pnpm build
-        language: system
-        pass_filenames: false
-        always_run: true
       - id: test:fixtures
         name: test:fixtures
         entry: pnpm test:fixtures
@@ -20,6 +14,12 @@ repos:
         language: system
         pass_filenames: false
         types: [file, ts]
+      - id: build
+        name: build
+        entry: pnpm build
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: prettier
         name: prettier
         entry: pnpm prettier

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The directory where the Terraform binary ought to be called. Defaults to `$GITHU
 > [!IMPORTANT]
 > `planfile` must be specified relative to the working directory.
 
-### `id`
+### `header`
 
-A custom identifier for the Terraform execution. This allows to distinguish multiple Terraform runs: each sticky pull
-request comment is tied to an ID.
+The header that is used for the pull request comment posted by this action. Changing the default allows to distinguish
+multiple Terraform runs: each sticky pull request comment is identified by its header.

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
     default: "."
   id:
-    description: A unique ID for the Terraform deployment.
+    description: A unique ID for the Terraform plan.
     required: false
 runs:
   using: node20

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,10 @@ inputs:
     description: The directory where the Terraform binary should be called.
     required: true
     default: "."
-  id:
-    description: A unique ID for the Terraform plan.
-    required: false
+  header:
+    description: The header to use for the pull request comment.
+    required: true
+    default: 📝 Terraform Plan
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -26169,13 +26169,10 @@ function renderBody(plan) {
 }
 function renderComment({
   plan,
-  id,
+  header,
   includeFooter
 }) {
-  let header = "## \u{1F4DD} Terraform Plan";
-  if ((id?.length ?? 0) > 0) {
-    header += ` - \`${id}\``;
-  }
+  let fullHeader = "## \u{1F4DD} Terraform Plan";
   const body = renderBody(plan);
   let footer = "";
   if (includeFooter === void 0 || includeFooter === true) {
@@ -26185,7 +26182,7 @@ function renderComment({
 
 _Triggered by @${github.context.actor}, Commit: \`${github.context.payload.pull_request.head.sha}\`_`;
   }
-  return `${header}
+  return `${fullHeader}
 
 ${body}${footer}`;
 }
@@ -30268,7 +30265,7 @@ async function run() {
     planfile: core.getInput("planfile", { required: true }),
     terraformCmd: core.getInput("terraform-cmd", { required: true }),
     workingDirectory: core.getInput("working-directory", { required: true }),
-    id: core.getInput("id")
+    header: core.getInput("header", { required: true })
   };
   const octokit = github2.getOctokit(inputs.token);
   const plan = await core.group(
@@ -30280,7 +30277,7 @@ async function run() {
     })
   );
   await core.group("Render comment", () => {
-    const comment = renderComment({ plan, id: inputs.id });
+    const comment = renderComment({ plan, header: inputs.header });
     return createOrUpdateComment({ octokit, content: comment });
   });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26172,7 +26172,7 @@ function renderComment({
   id,
   includeFooter
 }) {
-  let header = "## \u{1F4DD} Terraform Deployment";
+  let header = "## \u{1F4DD} Terraform Plan";
   if ((id?.length ?? 0) > 0) {
     header += ` - \`${id}\``;
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26172,7 +26172,6 @@ function renderComment({
   header,
   includeFooter
 }) {
-  let fullHeader = "## \u{1F4DD} Terraform Plan";
   const body = renderBody(plan);
   let footer = "";
   if (includeFooter === void 0 || includeFooter === true) {
@@ -26182,7 +26181,7 @@ function renderComment({
 
 _Triggered by @${github.context.actor}, Commit: \`${github.context.payload.pull_request.head.sha}\`_`;
   }
-  return `${fullHeader}
+  return `## ${header}
 
 ${body}${footer}`;
 }

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -51,18 +51,15 @@ function renderBody(plan: RenderedPlan): string {
 
 export function renderComment({
   plan,
-  id,
+  header,
   includeFooter
 }: {
   plan: RenderedPlan
-  id?: string
+  header: string
   includeFooter?: boolean
 }): string {
   // Build header
-  let header = '## 📝 Terraform Plan'
-  if ((id?.length ?? 0) > 0) {
-    header += ` - \`${id}\``
-  }
+  let fullHeader = '## 📝 Terraform Plan'
 
   // Build body
   const body = renderBody(plan)
@@ -75,7 +72,7 @@ export function renderComment({
       ` Commit: \`${(github.context.payload as PullRequestEvent).pull_request.head.sha}\`_`
   }
 
-  return `${header}\n\n${body}${footer}`
+  return `${fullHeader}\n\n${body}${footer}`
 }
 
 export async function createOrUpdateComment({

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -58,9 +58,6 @@ export function renderComment({
   header: string
   includeFooter?: boolean
 }): string {
-  // Build header
-  let fullHeader = '## 📝 Terraform Plan'
-
   // Build body
   const body = renderBody(plan)
 
@@ -72,7 +69,7 @@ export function renderComment({
       ` Commit: \`${(github.context.payload as PullRequestEvent).pull_request.head.sha}\`_`
   }
 
-  return `${fullHeader}\n\n${body}${footer}`
+  return `## ${header}\n\n${body}${footer}`
 }
 
 export async function createOrUpdateComment({

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -59,7 +59,7 @@ export function renderComment({
   includeFooter?: boolean
 }): string {
   // Build header
-  let header = '## 📝 Terraform Deployment'
+  let header = '## 📝 Terraform Plan'
   if ((id?.length ?? 0) > 0) {
     header += ` - \`${id}\``
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ async function run() {
     planfile: core.getInput('planfile', { required: true }),
     terraformCmd: core.getInput('terraform-cmd', { required: true }),
     workingDirectory: core.getInput('working-directory', { required: true }),
-    id: core.getInput('id')
+    header: core.getInput('header', { required: true })
   }
   const octokit = github.getOctokit(inputs.token)
 
@@ -25,7 +25,7 @@ async function run() {
 
   // 3) Post comment
   await core.group('Render comment', () => {
-    const comment = renderComment({ plan, id: inputs.id })
+    const comment = renderComment({ plan, header: inputs.header })
     return createOrUpdateComment({ octokit, content: comment })
   })
 }

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -8,7 +8,11 @@ test.each(['basic/0-create', 'basic/1-modify', 'basic/2-delete'])('parse-success
   const planTxt = fs.readFileSync(`tests/fixtures/${arg}/plan.txt`, 'utf-8')
   const planfile = parsePlanfileJSON(planJson)
   const renderedPlan = internalRenderPlan(planfile, planTxt)
-  const renderedComment = renderComment({ plan: renderedPlan, includeFooter: false })
+  const renderedComment = renderComment({
+    plan: renderedPlan,
+    header: '📝 Terraform Plan',
+    includeFooter: false
+  })
 
   if (process.env.GENERATE_FIXTURE === '1') {
     fs.writeFileSync(`tests/fixtures/${arg}/rendered.md`, renderedComment)

--- a/tests/fixtures/basic/0-create/rendered.md
+++ b/tests/fixtures/basic/0-create/rendered.md
@@ -1,4 +1,4 @@
-## 📝 Terraform Deployment
+## 📝 Terraform Plan
 
 **→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete.**
 

--- a/tests/fixtures/basic/1-modify/rendered.md
+++ b/tests/fixtures/basic/1-modify/rendered.md
@@ -1,4 +1,4 @@
-## 📝 Terraform Deployment
+## 📝 Terraform Plan
 
 **→ Resource Changes: 0 to create, 0 to update, 1 to re-create, 0 to delete.**
 

--- a/tests/fixtures/basic/2-delete/rendered.md
+++ b/tests/fixtures/basic/2-delete/rendered.md
@@ -1,4 +1,4 @@
-## 📝 Terraform Deployment
+## 📝 Terraform Plan
 
 **→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 1 to delete.**
 


### PR DESCRIPTION
# Motivation

Fixes #8.

@simonblake-mp, I simply changed the name here. I'm not entirely sure what's the most elegant way to make it configurable. To limit the number of action inputs, having both `header` (or something like that) and `id` seems a little overkill so maybe one should use `header` for both and get rid of `id`. For now, I don't want to introduce a breaking change though :eyes:
