### PR TITLE
fix: Handle comments above github size limit

### DIFF
--- a/src/comment.ts
+++ b/src/comment.ts
@@ -52,14 +52,17 @@ function renderBody(plan: RenderedPlan): string {
 export function renderComment({
   plan,
   header,
-  includeFooter
+  includeFooter,
+  bodyOverride,
 }: {
   plan: RenderedPlan
   header: string
   includeFooter?: boolean
+  bodyOverride?: string
+
 }): string {
-  // Build body
-  const body = renderBody(plan)
+  // Build body if bodyOverride is null
+  const body = bodyOverride ?? renderBody(plan)
 
   // Build footer
   let footer = ''

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -49,11 +49,19 @@ function renderBody(plan: RenderedPlan): string {
   return body
 }
 
+// Ensure comment size is within GitHub's limits
+export function isValidComment(comment: string) {
+  if (comment.length > 65535) {
+    return false
+  }
+  return true
+}
+
 export function renderComment({
   plan,
   header,
   includeFooter,
-  bodyOverride,
+  bodyOverride
 }: {
   plan: RenderedPlan
   header: string

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -57,6 +57,13 @@ export function isValidComment(comment: string) {
   return true
 }
 
+// Generate link to terraform plan file artifact
+export function generatePlanLink() {
+  const repo = github.context.repo
+  const runId = github.context.runId
+  return `https://github.com/${repo}/actions/runs/${runId}/artifacts`
+}
+
 export function renderComment({
   plan,
   header,
@@ -67,7 +74,6 @@ export function renderComment({
   header: string
   includeFooter?: boolean
   bodyOverride?: string
-
 }): string {
   // Build body if bodyOverride is null
   const body = bodyOverride ?? renderBody(plan)

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -64,13 +64,11 @@ export function generatePlanLink() {
 export function renderComment({
   plan,
   header,
-  includeFooter,
-  errorMessage
+  includeFooter
 }: {
   plan: RenderedPlan
   header: string
   includeFooter?: boolean
-  errorMessage?: string
 }): string {
   // Build body
   const body = renderBody(plan)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import { createOrUpdateComment, renderComment, isValidComment } from './comment'
+import { createOrUpdateComment, renderComment, isValidComment, generatePlanLink } from './comment'
 import { renderPlan } from './render'
 
 async function run() {
@@ -30,22 +30,19 @@ async function run() {
     // Check comment size
     if (isValidComment(commentFull)) {
       return createOrUpdateComment({ octokit, content: commentFull })
-    }
-    else {
+    } else {
       // Truncate comment and provide link to download plan file
-      const bodyOverride = `Terraform plan too large. Download plan file directly: [here](${getTerraformPlanLink()})`
-      const commentTruncated = renderComment({ plan, header: inputs.header, includeFooter: true, bodyOverride: bodyOverride })
+      const bodyOverride = `Terraform plan too large. Download plan file directly: [here](${generatePlanLink()})`
+      const commentTruncated = renderComment({
+        plan,
+        header: inputs.header,
+        includeFooter: true,
+        bodyOverride
+      })
 
-    return createOrUpdateComment({ octokit, content: commentTruncated })
+      return createOrUpdateComment({ octokit, content: commentTruncated })
     }
-  }
-)}
-
-// Generate link to terraform plan file artifact
-function getTerraformPlanLink() {
-  const repo = github.context.repo
-  const runId = github.context.runId
-  return `https://github.com/${repo}/actions/runs/${runId}/artifacts`
+  })
 }
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,14 +32,13 @@ async function run() {
       return createOrUpdateComment({ octokit, content: commentFull })
     } else {
       // Truncate comment and provide link to download plan file
-      const bodyOverride = `Terraform plan too large. Download plan file directly: [here](${generatePlanLink()})`
+      const errorMessage = `Terraform plan too large. Download plan file directly: [here](${generatePlanLink()})`
       const commentTruncated = renderComment({
         plan,
         header: inputs.header,
         includeFooter: true,
-        bodyOverride
+        errorMessage
       })
-
       return createOrUpdateComment({ octokit, content: commentTruncated })
     }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import { createOrUpdateComment, renderComment } from './comment'
+import { createOrUpdateComment, renderComment, isValidComment } from './comment'
 import { renderPlan } from './render'
 
 async function run() {
@@ -30,30 +30,22 @@ async function run() {
     // Check comment size
     if (isValidComment(commentFull)) {
       return createOrUpdateComment({ octokit, content: commentFull })
-    } 
+    }
     else {
       // Truncate comment and provide link to download plan file
-      let bodyOverride = `Terraform plan too large. Download plan file directly: [here](${getTerraformPlanLink()})`
+      const bodyOverride = `Terraform plan too large. Download plan file directly: [here](${getTerraformPlanLink()})`
       const commentTruncated = renderComment({ plan, header: inputs.header, includeFooter: true, bodyOverride: bodyOverride })
 
     return createOrUpdateComment({ octokit, content: commentTruncated })
     }
   }
-)
+)}
 
 // Generate link to terraform plan file artifact
 function getTerraformPlanLink() {
   const repo = github.context.repo
   const runId = github.context.runId
   return `https://github.com/${repo}/actions/runs/${runId}/artifacts`
-}
-
-// Ensure comment size is within GitHub's limits
-function isValidComment(comment: string) {
-  if (comment.length > 65535) {
-    return false
-  }
-  return true
 }
 
 async function main() {


### PR DESCRIPTION
# Motivation

To support Github's character limit of `65536` characters,  optionally display a link to the artefact files in case the plan is too longer to render as a comment. 

