### PR TITLE
fix: Handle plans with no resources

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30063,7 +30063,7 @@ var planfileSchema = z.object({
         ])
       })
     })
-  )
+  ).optional()
 });
 function parsePlanfileJSON(json) {
   return planfileSchema.parse(json);
@@ -30128,7 +30128,7 @@ function extractResources(names, humanReadablePlan) {
   );
 }
 function internalRenderPlan(structuredPlan, humanReadablePlan) {
-  if (structuredPlan.resource_changes.length === 0) {
+  if (structuredPlan.resource_changes === void 0 || structuredPlan.resource_changes.length === 0) {
     return {};
   }
   const createdResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["create"].toString()).map((r) => r.address);

--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -11,22 +11,24 @@ const planfileSchema = z.object({
       message: `Version ${v} of Terraform planfile is currently unsupported (must be version 1.x).`
     })
   ),
-  resource_changes: z.array(
-    z.object({
-      address: z.string(),
-      change: z.object({
-        actions: z.union([
-          z.tuple([z.literal('no-op')]),
-          z.tuple([z.literal('create')]),
-          z.tuple([z.literal('read')]),
-          z.tuple([z.literal('delete')]),
-          z.tuple([z.literal('update')]),
-          z.tuple([z.literal('delete'), z.literal('create')]),
-          z.tuple([z.literal('create'), z.literal('delete')])
-        ])
+  resource_changes: z
+    .array(
+      z.object({
+        address: z.string(),
+        change: z.object({
+          actions: z.union([
+            z.tuple([z.literal('no-op')]),
+            z.tuple([z.literal('create')]),
+            z.tuple([z.literal('read')]),
+            z.tuple([z.literal('delete')]),
+            z.tuple([z.literal('update')]),
+            z.tuple([z.literal('delete'), z.literal('create')]),
+            z.tuple([z.literal('create'), z.literal('delete')])
+          ])
+        })
       })
-    })
-  )
+    )
+    .optional()
 })
 
 export type StructuredPlanfile = z.infer<typeof planfileSchema>

--- a/src/render.ts
+++ b/src/render.ts
@@ -96,7 +96,10 @@ export function internalRenderPlan(
   humanReadablePlan: string
 ): RenderedPlan {
   // If there are no changes, we do not need to build any sections
-  if (structuredPlan.resource_changes.length === 0) {
+  if (
+    structuredPlan.resource_changes === undefined ||
+    structuredPlan.resource_changes.length === 0
+  ) {
     return {}
   }
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -3,21 +3,24 @@ import { internalRenderPlan } from '../src/render'
 import { parsePlanfileJSON } from '../src/planfile'
 import { renderComment } from '../src/comment'
 
-test.each(['basic/0-create', 'basic/1-modify', 'basic/2-delete'])('parse-successful', (arg) => {
-  const planJson = JSON.parse(fs.readFileSync(`tests/fixtures/${arg}/plan.json`, 'utf-8'))
-  const planTxt = fs.readFileSync(`tests/fixtures/${arg}/plan.txt`, 'utf-8')
-  const planfile = parsePlanfileJSON(planJson)
-  const renderedPlan = internalRenderPlan(planfile, planTxt)
-  const renderedComment = renderComment({
-    plan: renderedPlan,
-    header: '📝 Terraform Plan',
-    includeFooter: false
-  })
+test.each(['basic/0-create', 'basic/1-modify', 'basic/2-delete', 'basic/3-empty'])(
+  'parse-successful',
+  (arg) => {
+    const planJson = JSON.parse(fs.readFileSync(`tests/fixtures/${arg}/plan.json`, 'utf-8'))
+    const planTxt = fs.readFileSync(`tests/fixtures/${arg}/plan.txt`, 'utf-8')
+    const planfile = parsePlanfileJSON(planJson)
+    const renderedPlan = internalRenderPlan(planfile, planTxt)
+    const renderedComment = renderComment({
+      plan: renderedPlan,
+      header: '📝 Terraform Plan',
+      includeFooter: false
+    })
 
-  if (process.env.GENERATE_FIXTURE === '1') {
-    fs.writeFileSync(`tests/fixtures/${arg}/rendered.md`, renderedComment)
-  } else {
-    const expected = fs.readFileSync(`tests/fixtures/${arg}/rendered.md`, 'utf-8')
-    expect(renderedComment).toBe(expected)
+    if (process.env.GENERATE_FIXTURE === '1') {
+      fs.writeFileSync(`tests/fixtures/${arg}/rendered.md`, renderedComment)
+    } else {
+      const expected = fs.readFileSync(`tests/fixtures/${arg}/rendered.md`, 'utf-8')
+      expect(renderedComment).toBe(expected)
+    }
   }
-})
+)

--- a/tests/fixtures/basic/3-empty/main.tf
+++ b/tests/fixtures/basic/3-empty/main.tf
@@ -1,0 +1,1 @@
+terraform {}

--- a/tests/fixtures/basic/3-empty/plan.json
+++ b/tests/fixtures/basic/3-empty/plan.json
@@ -1,0 +1,13 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.8.2",
+  "planned_values": {
+    "root_module": {}
+  },
+  "configuration": {
+    "root_module": {}
+  },
+  "applyable": false,
+  "complete": true,
+  "errored": false
+}

--- a/tests/fixtures/basic/3-empty/plan.txt
+++ b/tests/fixtures/basic/3-empty/plan.txt
@@ -1,0 +1,5 @@
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.

--- a/tests/fixtures/basic/3-empty/rendered.md
+++ b/tests/fixtures/basic/3-empty/rendered.md
@@ -1,0 +1,3 @@
+## 📝 Terraform Plan
+
+**→ No Resource Changes!**

--- a/tests/fixtures/generate.sh
+++ b/tests/fixtures/generate.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 function run_step {
     pushd $1
+    mkdir -p .terraform
     terraform init
     terraform plan -out .terraform/planfile -state ../.tfstate
     terraform show -json .terraform/planfile | jq 'del(.timestamp)' > plan.json
@@ -18,5 +19,6 @@ find $SCRIPT_DIR -name '*.txt' -exec rm -f {} \+
 run_step "$SCRIPT_DIR/basic/0-create"
 run_step "$SCRIPT_DIR/basic/1-modify"
 run_step "$SCRIPT_DIR/basic/2-delete"
+run_step "$SCRIPT_DIR/basic/3-empty"
 
 find $SCRIPT_DIR -name '.tfstate*' -exec rm -f {} \+


### PR DESCRIPTION
Hello there! :wave: Thank you for this sublime action ❤️

# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

Sometimes we scaffold a new Terraform directory structure without resources yet, and the action fails on it because the `resource_changes` is missing: 

```
Error: [
  {
    "code": "invalid_type",
    "expected": "array",
    "received": "undefined",
    "path": [
      "resource_changes"
    ],
    "message": "Required"
  }
]
```

# Changes

<!-- What changes have been performed? -->

* Made `resource_changes` optional during validation with Zod (`z.optional()`)
* Return immediately when `resource_changes` is `undefined` when rendering
* Add a basic tests case for a directory with no resources 