### PR TITLE
ci: Use `pull_request_target` trigger for chore workflow

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -1,6 +1,6 @@
 name: Chore
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, edited, synchronize]
   push:


### PR DESCRIPTION
# Motivation

Labels are not assigned correctly for pull requests from forks.
