### PR TITLE
fix: Paginate list comments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30817,13 +30817,13 @@ async function createOrUpdateComment({
   octokit,
   content
 }) {
-  const comments = await octokit.rest.issues.listComments({
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: github.context.issue.number
   });
   const header = content.split("\n")[0];
-  for (const comment of comments.data) {
+  for (const comment of comments) {
     if (comment.body?.startsWith(header)) {
       await octokit.rest.issues.updateComment({
         owner: github.context.repo.owner,

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -77,7 +77,7 @@ export async function createOrUpdateComment({
   content: string
 }): Promise<void> {
   // Get all PR comments
-  const comments = await octokit.rest.issues.listComments({
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: github.context.issue.number
@@ -86,7 +86,7 @@ export async function createOrUpdateComment({
   // Check if any comment already starts with the header that we expect. If so,
   // let's update the comment with the new content.
   const header = content.split('\n')[0]
-  for (const comment of comments.data) {
+  for (const comment of comments) {
     if (comment.body?.startsWith(header)) {
       await octokit.rest.issues.updateComment({
         owner: github.context.repo.owner,


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

When there are many comments, the actions misses the existing comments beyond the first page and thus add new ones, basically leaking new comments until reaching the limit of 2500 comments per issue set by GitHub 

# Changes

<!-- What changes have been performed? -->

Wrap `octokit.rest.issues.listComments` with `octokit.paginate`: https://octokit.github.io/rest.js/v21/#pagination
