### PR TITLE
feat: Track and display import changes

### DIFF
--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -1,6 +1,23 @@
 import * as semver from 'semver'
 import { z } from 'zod'
 
+const planChangeSchema = z.object({
+  address: z.string(),
+  change: z.object({
+    actions: z.union([
+      z.tuple([z.literal('no-op')]),
+      z.tuple([z.literal('create')]),
+      z.tuple([z.literal('read')]),
+      z.tuple([z.literal('delete')]),
+      z.tuple([z.literal('update')]),
+      z.tuple([z.literal('delete'), z.literal('create')]),
+      z.tuple([z.literal('create'), z.literal('delete')]),
+      z.tuple([z.literal('forget')]),
+      z.tuple([z.literal('create'), z.literal('forget')])
+    ])
+  })
+});
+
 const planfileSchema = z.object({
   format_version: z.string().refine(
     (v) => {
@@ -11,29 +28,16 @@ const planfileSchema = z.object({
       message: `Version ${v} of Terraform planfile is currently unsupported (must be version 1.x).`
     })
   ),
+  resource_drift: z
+  .array(planChangeSchema)
+  .optional(),
   resource_changes: z
-    .array(
-      z.object({
-        address: z.string(),
-        change: z.object({
-          actions: z.union([
-            z.tuple([z.literal('no-op')]),
-            z.tuple([z.literal('create')]),
-            z.tuple([z.literal('read')]),
-            z.tuple([z.literal('delete')]),
-            z.tuple([z.literal('update')]),
-            z.tuple([z.literal('delete'), z.literal('create')]),
-            z.tuple([z.literal('create'), z.literal('delete')]),
-            z.tuple([z.literal('forget')]),
-            z.tuple([z.literal('create'), z.literal('forget')])
-          ])
-        })
-      })
-    )
+    .array(planChangeSchema)
     .optional()
 })
 
 export type StructuredPlanfile = z.infer<typeof planfileSchema>
+export type StructuredPlanChange = z.infer<typeof planChangeSchema>
 
 export function parsePlanfileJSON(json: string): StructuredPlanfile {
   return planfileSchema.parse(json)


### PR DESCRIPTION
# Motivation

Closes #32 

# Changes

The tfplan structure contains not only a `resource_changes` field, but also a `resource_drift` field.
`resource_drift` has the same internal type as `resource_changes`, so they now share a named type.