### PR TITLE
fix: Empty comment if OpenTofu is used with ephemeral resources

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40407,9 +40407,10 @@ async function renderPlan({
         options,
         humanReadablePlanfile
       });
+    } else {
+      throw error49;
     }
   }
-  return [];
 }
 
 // src/comment.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -40327,14 +40327,18 @@ _\u2192 ${content.reason}_`;
   }
   return result;
 }
-function extractResources(names, humanReadablePlan) {
+function extractResources(names, humanReadablePlan, suppressErrors = false) {
   if (names.length === 0) {
     return void 0;
   }
   return names.reduce(
     (acc, name) => {
-      const content = extractResourceContent(name, humanReadablePlan);
-      acc[name] = formatResourceContent(content);
+      try {
+        const content = extractResourceContent(name, humanReadablePlan);
+        acc[name] = formatResourceContent(content);
+      } catch (error49) {
+        if (!suppressErrors || error49 instanceof SyntaxError) throw error49;
+      }
       return acc;
     },
     {}
@@ -40356,7 +40360,7 @@ function internalRenderPlan(structuredPlan, humanReadablePlan) {
     updatedResources: extractResources(updatedResources, humanReadablePlan),
     recreatedResources: extractResources(recreatedResources, humanReadablePlan),
     deletedResources: extractResources(deletedResources, humanReadablePlan),
-    ephemeralResources: extractResources(ephemeralResources, humanReadablePlan)
+    ephemeralResources: extractResources(ephemeralResources, humanReadablePlan, true)
   };
 }
 async function renderTerraformPlan({

--- a/src/render.ts
+++ b/src/render.ts
@@ -93,15 +93,20 @@ function formatResourceContent(content: ResourceContent): string {
 
 function extractResources(
   names: string[],
-  humanReadablePlan: string
+  humanReadablePlan: string,
+  suppressErrors = false
 ): Record<string, string> | undefined {
   if (names.length === 0) {
     return undefined
   }
   return names.reduce(
     (acc, name) => {
-      const content = extractResourceContent(name, humanReadablePlan)
-      acc[name] = formatResourceContent(content)
+      try {
+        const content = extractResourceContent(name, humanReadablePlan)
+        acc[name] = formatResourceContent(content)
+      } catch (error) {
+        if (!suppressErrors || error instanceof SyntaxError) throw error
+      }
       return acc
     },
     {} as Record<string, string>
@@ -146,7 +151,7 @@ export function internalRenderPlan(
     updatedResources: extractResources(updatedResources, humanReadablePlan),
     recreatedResources: extractResources(recreatedResources, humanReadablePlan),
     deletedResources: extractResources(deletedResources, humanReadablePlan),
-    ephemeralResources: extractResources(ephemeralResources, humanReadablePlan)
+    ephemeralResources: extractResources(ephemeralResources, humanReadablePlan, true)
   }
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -227,7 +227,8 @@ export async function renderPlan({
         options,
         humanReadablePlanfile
       })
+    } else {
+      throw error
     }
   }
-  return []
 }


### PR DESCRIPTION
# Motivation

Make the use of this action possible with OpenTofu and ephemeral resources: 
https://github.com/borchero/terraform-plan-comment/issues/107

# Changes
* fix the try-catch in `renderPlan` function, by only catching the `SyntaxError` for the Terragrunt implementation
* add option to ignore the missing human-readable output for ephemeral resources
