### PR TITLE
fix: Rethrow generic errors from `renderTerraformPlan` try-catch block

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40407,9 +40407,10 @@ async function renderPlan({
         options,
         humanReadablePlanfile
       });
+    } else {
+      throw error49;
     }
   }
-  return [];
 }
 
 // src/comment.ts

--- a/src/render.ts
+++ b/src/render.ts
@@ -227,7 +227,9 @@ export async function renderPlan({
         options,
         humanReadablePlanfile
       })
+    } else {
+      // Re-throw unexpected errors
+      throw error
     }
   }
-  return []
 }


### PR DESCRIPTION
# Motivation

The try-catch block wrapping `renderTerraformPlan` is silencing any error that isn't a `SyntaxError`. This can make debugging significantly harder if `renderTerraformPlan` fails for other reasons. https://github.com/borchero/terraform-plan-comment/issues/107#issuecomment-4506274166
# Changes

Fix silent failures in `renderTerraformPlan` by re-throwing unhandled exceptions