### PR TITLE
fix: Treat stat-only changes as non-empty plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,5 +186,5 @@ This action provides the following output:
 
 Imports, moves and removals from state are counted independently of the resource actions, since Terraform can import,
 move or forget the same resource it also creates, updates or destroys. The two groups therefore overlap and must not be
-summed. `change-summary` reports them as two sentences (`Resource Changes: ...` and `State Changes: ...`) for that
-reason.
+summed. `change-summary` reports them in a separate `State Changes: ...` sentence for that reason, which is appended to
+the `Resource Changes: ...` sentence only when the plan actually contains imports, moves or removals from state.

--- a/README.md
+++ b/README.md
@@ -181,3 +181,10 @@ This action provides the following output:
 - `num-resources-recreated`: The number of resources to be recreated
 - `num-resources-ephemeral`: The number of ephemeral resources
 - `num-resources-imported`: The number of resources to be imported
+- `num-resources-moved`: The number of resources to be moved to a new address
+- `num-resources-forgotten`: The number of resources to be removed from state without being destroyed
+
+Imports, moves and removals from state are counted independently of the resource actions, since Terraform can import,
+move or forget the same resource it also creates, updates or destroys. The two groups therefore overlap and must not be
+summed. `change-summary` reports them as two sentences (`Resource Changes: ...` and `State Changes: ...`) for that
+reason.

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ outputs:
     description: The number of ephemeral resources
   num-resources-imported:
     description: The number of resources to be imported
+  num-resources-moved:
+    description: The number of resources to be moved to a new address
+  num-resources-forgotten:
+    description: The number of resources to be removed from state without being destroyed
 
 runs:
   using: node24

--- a/dist/index.js
+++ b/dist/index.js
@@ -40303,7 +40303,11 @@ function summarize(plans) {
   );
 }
 function summaryText(counts) {
-  return `Resource Changes: ${counts.created} to create, ${counts.updated} to update, ${counts.recreated} to re-create, ${counts.deleted} to delete, ${counts.ephemeral} ephemeral. State Changes: ${counts.imported} to import, ${counts.moved} to move, ${counts.forgotten} to remove from state.`;
+  const resourceChanges = `Resource Changes: ${counts.created} to create, ${counts.updated} to update, ${counts.recreated} to re-create, ${counts.deleted} to delete, ${counts.ephemeral} ephemeral.`;
+  if (counts.imported + counts.moved + counts.forgotten === 0) {
+    return resourceChanges;
+  }
+  return `${resourceChanges} State Changes: ${counts.imported} to import, ${counts.moved} to move, ${counts.forgotten} to remove from state.`;
 }
 function planIsEmpty(plan) {
   return !plan.createdResources && !plan.recreatedResources && !plan.updatedResources && !plan.deletedResources && !plan.ephemeralResources && !plan.importedResources && !plan.movedResources && !plan.forgottenResources;
@@ -40312,13 +40316,23 @@ function plansAreEmpty(plans) {
   return plans.every(planIsEmpty);
 }
 var TERRAFORM_DIFF_INDENTATION = 4;
+var RESOURCE_BLOCK_LINE = /^ *[-+~.<=/?⇄]{1,4} (resource|ephemeral)/;
+function isResourceHeader(line, name) {
+  for (const indent of ["  ", " "]) {
+    const header = `${indent}# ${name}`;
+    if (line === header || line.startsWith(`${header} `)) {
+      return true;
+    }
+  }
+  return false;
+}
 function extractResourceContent(name, humanReadablePlan) {
   const lines = humanReadablePlan.split("\n");
-  const resourceHeaderIndex = lines.findIndex((line) => line.startsWith(`  # ${name}`));
+  const resourceHeaderIndex = lines.findIndex((line) => isResourceHeader(line, name));
   if (resourceHeaderIndex < 0) {
     throw Error(`Resource '${name}' is modified but cannot be found in human-readable plan.`);
   }
-  let resourceLineIndex = lines.slice(resourceHeaderIndex).findIndex((line) => line.match(/.*[+-~⇄] (resource|ephemeral)/));
+  let resourceLineIndex = lines.slice(resourceHeaderIndex).findIndex((line) => line.match(RESOURCE_BLOCK_LINE));
   if (resourceLineIndex < 0) {
     throw Error(`Resource block cannot be found for resource '${name}'.`);
   }
@@ -40474,21 +40488,15 @@ ${content}
   }
   return result;
 }
-function renderAddresses(addresses) {
-  let result = "";
-  for (const address of [...addresses].sort()) {
-    result += `
-
-- \`${address}\``;
-  }
-  return result;
+function inlineCode(value) {
+  return `\`${value}\``;
 }
-function renderMovedAddresses(moved) {
+function renderList(items) {
   let result = "";
-  for (const address of Object.keys(moved).sort()) {
+  for (const item of [...items].sort()) {
     result += `
 
-- \`${moved[address]}\` \u2192 \`${address}\``;
+- ${item}`;
   }
   return result;
 }
@@ -40519,15 +40527,19 @@ function renderBody(plan, options) {
   }
   if (plan.importedResources) {
     body += "\n\n### \u{1F4E5} Import";
-    body += renderAddresses(plan.importedResources);
+    body += renderList(plan.importedResources.map(inlineCode));
   }
   if (plan.movedResources) {
     body += "\n\n### \u{1F9ED} Move";
-    body += renderMovedAddresses(plan.movedResources);
+    body += renderList(
+      Object.entries(plan.movedResources).map(
+        ([to, from]) => `${inlineCode(from)} \u2192 ${inlineCode(to)}`
+      )
+    );
   }
   if (plan.forgottenResources) {
     body += "\n\n### \u{1F4E4} Remove From State";
-    body += renderAddresses(plan.forgottenResources);
+    body += renderList(plan.forgottenResources.map(inlineCode));
   }
   return body;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -40254,6 +40254,7 @@ var planfileSchema = external_exports.object({
   resource_changes: external_exports.array(
     external_exports.object({
       address: external_exports.string(),
+      previous_address: external_exports.string().optional(),
       change: external_exports.object({
         actions: external_exports.union([
           external_exports.tuple([external_exports.literal("no-op")]),
@@ -40285,16 +40286,27 @@ function summarize(plans) {
       recreated: acc.recreated + Object.keys(plan.recreatedResources ?? {}).length,
       deleted: acc.deleted + Object.keys(plan.deletedResources ?? {}).length,
       ephemeral: acc.ephemeral + Object.keys(plan.ephemeralResources ?? {}).length,
-      imported: acc.imported + (plan.importedCount ?? 0)
+      imported: acc.imported + (plan.importedResources ?? []).length,
+      moved: acc.moved + Object.keys(plan.movedResources ?? {}).length,
+      forgotten: acc.forgotten + (plan.forgottenResources ?? []).length
     }),
-    { created: 0, updated: 0, recreated: 0, deleted: 0, ephemeral: 0, imported: 0 }
+    {
+      created: 0,
+      updated: 0,
+      recreated: 0,
+      deleted: 0,
+      ephemeral: 0,
+      imported: 0,
+      moved: 0,
+      forgotten: 0
+    }
   );
 }
 function summaryText(counts) {
-  return `Resource Changes: ${counts.created} to create, ${counts.updated} to update, ${counts.recreated} to re-create, ${counts.deleted} to delete, ${counts.ephemeral} ephemeral, ${counts.imported} to import.`;
+  return `Resource Changes: ${counts.created} to create, ${counts.updated} to update, ${counts.recreated} to re-create, ${counts.deleted} to delete, ${counts.ephemeral} ephemeral. State Changes: ${counts.imported} to import, ${counts.moved} to move, ${counts.forgotten} to remove from state.`;
 }
 function planIsEmpty(plan) {
-  return !plan.createdResources && !plan.recreatedResources && !plan.updatedResources && !plan.deletedResources && !plan.ephemeralResources;
+  return !plan.createdResources && !plan.recreatedResources && !plan.updatedResources && !plan.deletedResources && !plan.ephemeralResources && !plan.importedResources && !plan.movedResources && !plan.forgottenResources;
 }
 function plansAreEmpty(plans) {
   return plans.every(planIsEmpty);
@@ -40361,23 +40373,35 @@ function internalRenderPlan(structuredPlan, humanReadablePlan) {
   if (structuredPlan.resource_changes === void 0 || structuredPlan.resource_changes.length === 0) {
     return {};
   }
-  const createdResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["create"].toString()).map((r) => r.address);
+  const createdResources = structuredPlan.resource_changes.filter(
+    (r) => r.change.actions.toString() === ["create"].toString() || r.change.actions.toString() === ["create", "forget"].toString()
+  ).map((r) => r.address);
   const updatedResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["update"].toString()).map((r) => r.address);
   const recreatedResources = structuredPlan.resource_changes.filter(
     (r) => r.change.actions.toString() === ["delete", "create"].toString() || r.change.actions.toString() === ["create", "delete"].toString()
   ).map((r) => r.address);
   const deletedResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["delete"].toString()).map((r) => r.address);
   const ephemeralResources = structuredPlan.resource_changes.filter((r) => r.change.actions.toString() === ["open"].toString()).map((r) => r.address);
-  const importedCount = structuredPlan.resource_changes.filter(
-    (r) => r.change.importing !== void 0
-  ).length;
+  const importedResources = structuredPlan.resource_changes.filter((r) => r.change.importing !== void 0).map((r) => r.address);
+  const movedResources = structuredPlan.resource_changes.filter((r) => r.previous_address !== void 0).reduce(
+    (acc, r) => {
+      acc[r.address] = r.previous_address;
+      return acc;
+    },
+    {}
+  );
+  const forgottenResources = structuredPlan.resource_changes.filter(
+    (r) => r.change.actions.toString() === ["forget"].toString() || r.change.actions.toString() === ["create", "forget"].toString()
+  ).map((r) => r.address);
   return {
     createdResources: extractResources(createdResources, humanReadablePlan),
     updatedResources: extractResources(updatedResources, humanReadablePlan),
     recreatedResources: extractResources(recreatedResources, humanReadablePlan),
     deletedResources: extractResources(deletedResources, humanReadablePlan),
     ephemeralResources: extractResources(ephemeralResources, humanReadablePlan),
-    importedCount: importedCount > 0 ? importedCount : void 0
+    importedResources: importedResources.length > 0 ? importedResources : void 0,
+    movedResources: Object.keys(movedResources).length > 0 ? movedResources : void 0,
+    forgottenResources: forgottenResources.length > 0 ? forgottenResources : void 0
   };
 }
 async function renderTerraformPlan({
@@ -40450,6 +40474,24 @@ ${content}
   }
   return result;
 }
+function renderAddresses(addresses) {
+  let result = "";
+  for (const address of [...addresses].sort()) {
+    result += `
+
+- \`${address}\``;
+  }
+  return result;
+}
+function renderMovedAddresses(moved) {
+  let result = "";
+  for (const address of Object.keys(moved).sort()) {
+    result += `
+
+- \`${moved[address]}\` \u2192 \`${address}\``;
+  }
+  return result;
+}
 function renderBody(plan, options) {
   if (planIsEmpty(plan)) {
     return "";
@@ -40474,6 +40516,18 @@ function renderBody(plan, options) {
   if (plan.ephemeralResources) {
     body += "\n\n### \u{1F47B} Ephemeral";
     body += renderResources(plan.ephemeralResources, options);
+  }
+  if (plan.importedResources) {
+    body += "\n\n### \u{1F4E5} Import";
+    body += renderAddresses(plan.importedResources);
+  }
+  if (plan.movedResources) {
+    body += "\n\n### \u{1F9ED} Move";
+    body += renderMovedAddresses(plan.movedResources);
+  }
+  if (plan.forgottenResources) {
+    body += "\n\n### \u{1F4E4} Remove From State";
+    body += renderAddresses(plan.forgottenResources);
   }
   return body;
 }
@@ -40656,6 +40710,8 @@ async function run() {
   setOutput("num-resources-recreated", counts.recreated);
   setOutput("num-resources-ephemeral", counts.ephemeral);
   setOutput("num-resources-imported", counts.imported);
+  setOutput("num-resources-moved", counts.moved);
+  setOutput("num-resources-forgotten", counts.forgotten);
   await group("Adding plan to step summary", async () => {
     await summary.addRaw(planMarkdown).write();
   });

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -16,18 +16,15 @@ function renderResources(
   return result
 }
 
-function renderAddresses(addresses: string[]): string {
-  let result = ''
-  for (const address of [...addresses].sort()) {
-    result += `\n\n- \`${address}\``
-  }
-  return result
+function inlineCode(value: string): string {
+  return `\`${value}\``
 }
 
-function renderMovedAddresses(moved: Record<string, string>): string {
+// Sorting the rendered items keeps the list ordered by the address it leads with.
+function renderList(items: string[]): string {
   let result = ''
-  for (const address of Object.keys(moved).sort()) {
-    result += `\n\n- \`${moved[address]}\` → \`${address}\``
+  for (const item of [...items].sort()) {
+    result += `\n\n- ${item}`
   }
   return result
 }
@@ -63,15 +60,19 @@ function renderBody(plan: RenderedPlan, options: { expandDetails: boolean }): st
   // State changes carry no diff to show, so they are listed by address instead of as <details>.
   if (plan.importedResources) {
     body += '\n\n### 📥 Import'
-    body += renderAddresses(plan.importedResources)
+    body += renderList(plan.importedResources.map(inlineCode))
   }
   if (plan.movedResources) {
     body += '\n\n### 🧭 Move'
-    body += renderMovedAddresses(plan.movedResources)
+    body += renderList(
+      Object.entries(plan.movedResources).map(
+        ([to, from]) => `${inlineCode(from)} → ${inlineCode(to)}`
+      )
+    )
   }
   if (plan.forgottenResources) {
     body += '\n\n### 📤 Remove From State'
-    body += renderAddresses(plan.forgottenResources)
+    body += renderList(plan.forgottenResources.map(inlineCode))
   }
 
   return body

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -16,6 +16,22 @@ function renderResources(
   return result
 }
 
+function renderAddresses(addresses: string[]): string {
+  let result = ''
+  for (const address of [...addresses].sort()) {
+    result += `\n\n- \`${address}\``
+  }
+  return result
+}
+
+function renderMovedAddresses(moved: Record<string, string>): string {
+  let result = ''
+  for (const address of Object.keys(moved).sort()) {
+    result += `\n\n- \`${moved[address]}\` → \`${address}\``
+  }
+  return result
+}
+
 function renderBody(plan: RenderedPlan, options: { expandDetails: boolean }): string {
   if (planIsEmpty(plan)) {
     return ''
@@ -42,6 +58,20 @@ function renderBody(plan: RenderedPlan, options: { expandDetails: boolean }): st
   if (plan.ephemeralResources) {
     body += '\n\n### 👻 Ephemeral'
     body += renderResources(plan.ephemeralResources, options)
+  }
+
+  // State changes carry no diff to show, so they are listed by address instead of as <details>.
+  if (plan.importedResources) {
+    body += '\n\n### 📥 Import'
+    body += renderAddresses(plan.importedResources)
+  }
+  if (plan.movedResources) {
+    body += '\n\n### 🧭 Move'
+    body += renderMovedAddresses(plan.movedResources)
+  }
+  if (plan.forgottenResources) {
+    body += '\n\n### 📤 Remove From State'
+    body += renderAddresses(plan.forgottenResources)
   }
 
   return body

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ async function run() {
   core.setOutput('num-resources-recreated', counts.recreated)
   core.setOutput('num-resources-ephemeral', counts.ephemeral)
   core.setOutput('num-resources-imported', counts.imported)
+  core.setOutput('num-resources-moved', counts.moved)
+  core.setOutput('num-resources-forgotten', counts.forgotten)
 
   // 5) Add plan to GitHub step summary
   await core.group('Adding plan to step summary', async () => {

--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -15,6 +15,7 @@ const planfileSchema = z.object({
     .array(
       z.object({
         address: z.string(),
+        previous_address: z.string().optional(),
         change: z.object({
           actions: z.union([
             z.tuple([z.literal('no-op')]),

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,7 +8,10 @@ export type RenderedPlan = {
   recreatedResources?: Record<string, string>
   deletedResources?: Record<string, string>
   ephemeralResources?: Record<string, string>
-  importedCount?: number
+  importedResources?: string[]
+  // Maps the new address of a moved resource to the address it moved from.
+  movedResources?: Record<string, string>
+  forgottenResources?: string[]
 }
 
 export type ResourceCounts = {
@@ -18,6 +21,8 @@ export type ResourceCounts = {
   deleted: number
   ephemeral: number
   imported: number
+  moved: number
+  forgotten: number
 }
 
 export function summarize(plans: RenderedPlan[]): ResourceCounts {
@@ -28,20 +33,36 @@ export function summarize(plans: RenderedPlan[]): ResourceCounts {
       recreated: acc.recreated + Object.keys(plan.recreatedResources ?? {}).length,
       deleted: acc.deleted + Object.keys(plan.deletedResources ?? {}).length,
       ephemeral: acc.ephemeral + Object.keys(plan.ephemeralResources ?? {}).length,
-      imported: acc.imported + (plan.importedCount ?? 0)
+      imported: acc.imported + (plan.importedResources ?? []).length,
+      moved: acc.moved + Object.keys(plan.movedResources ?? {}).length,
+      forgotten: acc.forgotten + (plan.forgottenResources ?? []).length
     }),
-    { created: 0, updated: 0, recreated: 0, deleted: 0, ephemeral: 0, imported: 0 }
+    {
+      created: 0,
+      updated: 0,
+      recreated: 0,
+      deleted: 0,
+      ephemeral: 0,
+      imported: 0,
+      moved: 0,
+      forgotten: 0
+    }
   )
 }
 
+// State changes are reported as a separate sentence because they are a different axis to the
+// resource actions, not a further partition of them: Terraform can import, move or forget the
+// same resource it also creates, updates or destroys, so the two groups must not be summed.
 export function summaryText(counts: ResourceCounts): string {
   return (
     `Resource Changes: ${counts.created} to create, ` +
     `${counts.updated} to update, ` +
     `${counts.recreated} to re-create, ` +
     `${counts.deleted} to delete, ` +
-    `${counts.ephemeral} ephemeral, ` +
-    `${counts.imported} to import.`
+    `${counts.ephemeral} ephemeral. ` +
+    `State Changes: ${counts.imported} to import, ` +
+    `${counts.moved} to move, ` +
+    `${counts.forgotten} to remove from state.`
   )
 }
 
@@ -51,7 +72,10 @@ export function planIsEmpty(plan: RenderedPlan): boolean {
     !plan.recreatedResources &&
     !plan.updatedResources &&
     !plan.deletedResources &&
-    !plan.ephemeralResources
+    !plan.ephemeralResources &&
+    !plan.importedResources &&
+    !plan.movedResources &&
+    !plan.forgottenResources
   )
 }
 
@@ -157,7 +181,11 @@ export function internalRenderPlan(
 
   // Partition changes for output formatting and extract resources
   const createdResources = structuredPlan.resource_changes
-    .filter((r) => r.change.actions.toString() === ['create'].toString())
+    .filter(
+      (r) =>
+        r.change.actions.toString() === ['create'].toString() ||
+        r.change.actions.toString() === ['create', 'forget'].toString()
+    )
     .map((r) => r.address)
   const updatedResources = structuredPlan.resource_changes
     .filter((r) => r.change.actions.toString() === ['update'].toString())
@@ -175,9 +203,27 @@ export function internalRenderPlan(
   const ephemeralResources = structuredPlan.resource_changes
     .filter((r) => r.change.actions.toString() === ['open'].toString())
     .map((r) => r.address)
-  const importedCount = structuredPlan.resource_changes.filter(
-    (r) => r.change.importing !== undefined
-  ).length
+  // A resource can be imported, moved or forgotten *and* changed, so these overlap with the
+  // action-based partitions above and are collected independently of them.
+  const importedResources = structuredPlan.resource_changes
+    .filter((r) => r.change.importing !== undefined)
+    .map((r) => r.address)
+  const movedResources = structuredPlan.resource_changes
+    .filter((r) => r.previous_address !== undefined)
+    .reduce(
+      (acc, r) => {
+        acc[r.address] = r.previous_address as string
+        return acc
+      },
+      {} as Record<string, string>
+    )
+  const forgottenResources = structuredPlan.resource_changes
+    .filter(
+      (r) =>
+        r.change.actions.toString() === ['forget'].toString() ||
+        r.change.actions.toString() === ['create', 'forget'].toString()
+    )
+    .map((r) => r.address)
 
   return {
     createdResources: extractResources(createdResources, humanReadablePlan),
@@ -185,7 +231,9 @@ export function internalRenderPlan(
     recreatedResources: extractResources(recreatedResources, humanReadablePlan),
     deletedResources: extractResources(deletedResources, humanReadablePlan),
     ephemeralResources: extractResources(ephemeralResources, humanReadablePlan),
-    importedCount: importedCount > 0 ? importedCount : undefined
+    importedResources: importedResources.length > 0 ? importedResources : undefined,
+    movedResources: Object.keys(movedResources).length > 0 ? movedResources : undefined,
+    forgottenResources: forgottenResources.length > 0 ? forgottenResources : undefined
   }
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -50,17 +50,18 @@ export function summarize(plans: RenderedPlan[]): ResourceCounts {
   )
 }
 
-// State changes are reported as a separate sentence because they are a different axis to the
-// resource actions, not a further partition of them: Terraform can import, move or forget the
-// same resource it also creates, updates or destroys, so the two groups must not be summed.
 export function summaryText(counts: ResourceCounts): string {
-  return (
+  const resourceChanges =
     `Resource Changes: ${counts.created} to create, ` +
     `${counts.updated} to update, ` +
     `${counts.recreated} to re-create, ` +
     `${counts.deleted} to delete, ` +
-    `${counts.ephemeral} ephemeral. ` +
-    `State Changes: ${counts.imported} to import, ` +
+    `${counts.ephemeral} ephemeral.`
+  if (counts.imported + counts.moved + counts.forgotten === 0) {
+    return resourceChanges
+  }
+  return (
+    `${resourceChanges} State Changes: ${counts.imported} to import, ` +
     `${counts.moved} to move, ` +
     `${counts.forgotten} to remove from state.`
   )
@@ -90,17 +91,36 @@ type ResourceContent = {
 
 const TERRAFORM_DIFF_INDENTATION = 4
 
+// Terraform starts the resource block with an action symbol whose last character is one of these,
+// e.g. `  +`, `  ~`, `-/+`, ` .` or ` +/.` (see `internal/command/format.DiffActionSymbol`). The
+// symbol is anchored to the start of the line so that comments mentioning a resource in prose are
+// not mistaken for it.
+const RESOURCE_BLOCK_LINE = /^ *[-+~.<=/?⇄]{1,4} (resource|ephemeral)/
+
+function isResourceHeader(line: string, name: string): boolean {
+  // Terraform indents the comment by two spaces, but its `forget` and `create`-then-`forget`
+  // branches hardcode a single space instead.
+  for (const indent of ['  ', ' ']) {
+    const header = `${indent}# ${name}`
+    // The address has to end here, otherwise `local_file.test` matches `local_file.test2` too.
+    if (line === header || line.startsWith(`${header} `)) {
+      return true
+    }
+  }
+  return false
+}
+
 function extractResourceContent(name: string, humanReadablePlan: string): ResourceContent {
   const lines = humanReadablePlan.split('\n')
 
   // In the plan, find the resource with the appropriate name
-  const resourceHeaderIndex = lines.findIndex((line) => line.startsWith(`  # ${name}`))
+  const resourceHeaderIndex = lines.findIndex((line) => isResourceHeader(line, name))
   if (resourceHeaderIndex < 0) {
     throw Error(`Resource '${name}' is modified but cannot be found in human-readable plan.`)
   }
   let resourceLineIndex = lines
     .slice(resourceHeaderIndex)
-    .findIndex((line) => line.match(/.*[+-~⇄] (resource|ephemeral)/))
+    .findIndex((line) => line.match(RESOURCE_BLOCK_LINE))
   if (resourceLineIndex < 0) {
     throw Error(`Resource block cannot be found for resource '${name}'.`)
   }

--- a/tests/comment.test.ts
+++ b/tests/comment.test.ts
@@ -1,4 +1,5 @@
-import { chunkComment } from '../src/comment'
+import { chunkComment, renderMarkdown } from '../src/comment'
+import type { RenderedPlan } from '../src/render'
 
 describe('chunkComment', () => {
   const header = '## Terraform Plan'
@@ -51,5 +52,34 @@ describe('chunkComment', () => {
     for (const chunk of chunks) {
       expect(chunk.length).toBeLessThanOrEqual(65000)
     }
+  })
+})
+
+describe('renderMarkdown state changes', () => {
+  function render(plan: RenderedPlan): string {
+    return renderMarkdown({
+      plans: [plan],
+      header: '📝 Terraform Plan',
+      includeFooter: false,
+      expandDetails: false
+    })
+  }
+
+  test('moves are listed in order of the address they moved from', () => {
+    const body = render({
+      movedResources: {
+        'module.z.local_file.x': 'module.old_b.local_file.x',
+        'module.a.local_file.y': 'module.old_a.local_file.y'
+      }
+    })
+    expect(body).toContain(
+      '- `module.old_a.local_file.y` → `module.a.local_file.y`\n\n' +
+        '- `module.old_b.local_file.x` → `module.z.local_file.x`'
+    )
+  })
+
+  test('the summary omits state changes when there are none', () => {
+    expect(render({ forgottenResources: ['local_file.a'] })).toContain('State Changes:')
+    expect(render({ createdResources: { 'local_file.a': 'diff' } })).not.toContain('State Changes:')
   })
 })

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,7 +24,10 @@ test.each([
   'basic/3-remove',
   'basic/4-empty',
   'basic/7-create-hundreds',
-  'ephemeral/0-create'
+  'ephemeral/0-create',
+  'import/0-import',
+  'move/0-create',
+  'move/1-move'
 ])('parse-successful', (arg) => {
   const planJson = JSON.parse(fs.readFileSync(`tests/fixtures/${arg}/plan.json`, 'utf-8'))
   const planTxt = fs.readFileSync(`tests/fixtures/${arg}/plan.txt`, 'utf-8')

--- a/tests/fixtures/basic/0-create/rendered.md
+++ b/tests/fixtures/basic/0-create/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 3 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 3 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/0-create/rendered.md
+++ b/tests/fixtures/basic/0-create/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 3 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 3 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/1-modify/rendered.md
+++ b/tests/fixtures/basic/1-modify/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 0 to create, 0 to update, 2 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 0 to create, 0 to update, 2 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ⚙️ Re-Create
 

--- a/tests/fixtures/basic/1-modify/rendered.md
+++ b/tests/fixtures/basic/1-modify/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 0 to create, 0 to update, 2 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 0 to create, 0 to update, 2 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ⚙️ Re-Create
 

--- a/tests/fixtures/basic/2-delete/rendered.md
+++ b/tests/fixtures/basic/2-delete/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 2 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 2 to delete, 0 ephemeral.**
 
 ### 🗑️ Delete
 

--- a/tests/fixtures/basic/2-delete/rendered.md
+++ b/tests/fixtures/basic/2-delete/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 2 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 2 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### 🗑️ Delete
 

--- a/tests/fixtures/basic/3-remove/rendered.md
+++ b/tests/fixtures/basic/3-remove/rendered.md
@@ -1,3 +1,7 @@
 ## 📝 Terraform Plan
 
-**→ No Resource Changes!**
+**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 1 to remove from state.**
+
+### 📤 Remove From State
+
+- `local_file.test2`

--- a/tests/fixtures/basic/5-terragrunt/rendered.md
+++ b/tests/fixtures/basic/5-terragrunt/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terragrunt Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/6-terragrunt-multiplan/rendered.md
+++ b/tests/fixtures/basic/6-terragrunt-multiplan/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terragrunt Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 
@@ -22,7 +22,7 @@
 
 </details>
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 
@@ -44,7 +44,7 @@
 
 </details>
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/6-terragrunt-multiplan/rendered.md
+++ b/tests/fixtures/basic/6-terragrunt-multiplan/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terragrunt Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 
@@ -22,7 +22,7 @@
 
 </details>
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 
@@ -44,7 +44,7 @@
 
 </details>
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/7-create-hundreds/rendered.md
+++ b/tests/fixtures/basic/7-create-hundreds/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 300 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 300 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/basic/7-create-hundreds/rendered.md
+++ b/tests/fixtures/basic/7-create-hundreds/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 300 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 300 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 

--- a/tests/fixtures/ephemeral/0-create/rendered.md
+++ b/tests/fixtures/ephemeral/0-create/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/ephemeral/0-create/rendered.md
+++ b/tests/fixtures/ephemeral/0-create/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral, 0 to import.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 

--- a/tests/fixtures/generate.sh
+++ b/tests/fixtures/generate.sh
@@ -55,6 +55,10 @@ run_step_terragrunt "$SCRIPT_DIR/basic/6-terragrunt-multiplan"
 
 run_step_terraform "$SCRIPT_DIR/basic/7-create-hundreds"
 run_step_without_apply "$SCRIPT_DIR/ephemeral/0-create"
+run_step_without_apply "$SCRIPT_DIR/import/0-import"
+
+run_step_terraform "$SCRIPT_DIR/move/0-create"
+run_step_without_apply "$SCRIPT_DIR/move/1-move"
 
 find $SCRIPT_DIR -name '.tfstate*' -exec rm -f {} \+
 find $SCRIPT_DIR -name '.terraform.lock.hcl' -exec rm -f {} \+

--- a/tests/fixtures/import/0-import/main.tf
+++ b/tests/fixtures/import/0-import/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "local" {
+    path = "../.tfstate"
+  }
+}
+
+resource "terraform_data" "test" {}
+
+import {
+  to = terraform_data.test
+  id = "imported-id"
+}

--- a/tests/fixtures/import/0-import/plan.json
+++ b/tests/fixtures/import/0-import/plan.json
@@ -1,0 +1,105 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "terraform_data.test",
+          "mode": "managed",
+          "type": "terraform_data",
+          "name": "test",
+          "provider_name": "terraform.io/builtin/terraform",
+          "schema_version": 0,
+          "values": {
+            "id": "imported-id",
+            "input": null,
+            "output": null,
+            "triggers_replace": null
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "terraform_data.test",
+      "mode": "managed",
+      "type": "terraform_data",
+      "name": "test",
+      "provider_name": "terraform.io/builtin/terraform",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "imported-id",
+          "input": null,
+          "output": null,
+          "triggers_replace": null
+        },
+        "after": {
+          "id": "imported-id",
+          "input": null,
+          "output": null,
+          "triggers_replace": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {},
+        "importing": {
+          "id": "imported-id"
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.13.5",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "terraform_data.test",
+            "mode": "managed",
+            "type": "terraform_data",
+            "name": "test",
+            "provider_name": "terraform.io/builtin/terraform",
+            "schema_version": 0,
+            "values": {
+              "id": "imported-id",
+              "input": null,
+              "output": null,
+              "triggers_replace": null
+            },
+            "sensitive_values": {}
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "terraform": {
+        "name": "terraform",
+        "full_name": "terraform.io/builtin/terraform"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "terraform_data.test",
+          "mode": "managed",
+          "type": "terraform_data",
+          "name": "test",
+          "provider_config_key": "terraform",
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/tests/fixtures/import/0-import/plan.txt
+++ b/tests/fixtures/import/0-import/plan.txt
@@ -1,0 +1,9 @@
+
+Terraform will perform the following actions:
+
+  # terraform_data.test will be imported
+    resource "terraform_data" "test" {
+        id = "imported-id"
+    }
+
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

--- a/tests/fixtures/import/0-import/rendered.md
+++ b/tests/fixtures/import/0-import/rendered.md
@@ -1,0 +1,7 @@
+## 📝 Terraform Plan
+
+**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 1 to import, 0 to move, 0 to remove from state.**
+
+### 📥 Import
+
+- `terraform_data.test`

--- a/tests/fixtures/move/0-create/main.tf
+++ b/tests/fixtures/move/0-create/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "local" {
+    path = "../.tfstate"
+  }
+
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+resource "local_file" "before" {
+  filename = "../test-move.txt"
+  content  = "foobar"
+}

--- a/tests/fixtures/move/0-create/plan.json
+++ b/tests/fixtures/move/0-create/plan.json
@@ -1,0 +1,98 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "local_file.before",
+          "mode": "managed",
+          "type": "local_file",
+          "name": "before",
+          "provider_name": "registry.terraform.io/hashicorp/local",
+          "schema_version": 0,
+          "values": {
+            "content": "foobar",
+            "content_base64": null,
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "../test-move.txt",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_values": {
+            "sensitive_content": true
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "local_file.before",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "before",
+      "provider_name": "registry.terraform.io/hashicorp/local",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "content": "foobar",
+          "content_base64": null,
+          "directory_permission": "0777",
+          "file_permission": "0777",
+          "filename": "../test-move.txt",
+          "sensitive_content": null,
+          "source": null
+        },
+        "after_unknown": {
+          "content_base64sha256": true,
+          "content_base64sha512": true,
+          "content_md5": true,
+          "content_sha1": true,
+          "content_sha256": true,
+          "content_sha512": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "sensitive_content": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "local": {
+        "name": "local",
+        "full_name": "registry.terraform.io/hashicorp/local"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "local_file.before",
+          "mode": "managed",
+          "type": "local_file",
+          "name": "before",
+          "provider_config_key": "local",
+          "expressions": {
+            "content": {
+              "constant_value": "foobar"
+            },
+            "filename": {
+              "constant_value": "../test-move.txt"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/tests/fixtures/move/0-create/plan.txt
+++ b/tests/fixtures/move/0-create/plan.txt
@@ -1,0 +1,23 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.before will be created
+  + resource "local_file" "before" {
+      + content              = "foobar"
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "../test-move.txt"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/tests/fixtures/move/0-create/rendered.md
+++ b/tests/fixtures/move/0-create/rendered.md
@@ -1,6 +1,6 @@
 ## 📝 Terraform Plan
 
-**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
+**→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral.**
 
 ### ✨ Create
 

--- a/tests/fixtures/move/0-create/rendered.md
+++ b/tests/fixtures/move/0-create/rendered.md
@@ -1,13 +1,13 @@
-## 📝 Terragrunt Plan
+## 📝 Terraform Plan
 
 **→ Resource Changes: 1 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 0 to move, 0 to remove from state.**
 
 ### ✨ Create
 
-<details><summary><code>local_file.database</code></summary>
+<details><summary><code>local_file.before</code></summary>
 
 ```diff
-+ content              = (sensitive value)
++ content              = "foobar"
 + content_base64sha256 = (known after apply)
 + content_base64sha512 = (known after apply)
 + content_md5          = (known after apply)
@@ -16,7 +16,7 @@
 + content_sha512       = (known after apply)
 + directory_permission = "0777"
 + file_permission      = "0777"
-+ filename             = "../test.txt"
++ filename             = "../test-move.txt"
 + id                   = (known after apply)
 ```
 

--- a/tests/fixtures/move/1-move/main.tf
+++ b/tests/fixtures/move/1-move/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "local" {
+    path = "../.tfstate"
+  }
+
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+resource "local_file" "after" {
+  filename = "../test-move.txt"
+  content  = "foobar"
+}
+
+moved {
+  from = local_file.before
+  to   = local_file.after
+}

--- a/tests/fixtures/move/1-move/plan.json
+++ b/tests/fixtures/move/1-move/plan.json
@@ -1,0 +1,159 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "local_file.after",
+          "mode": "managed",
+          "type": "local_file",
+          "name": "after",
+          "provider_name": "registry.terraform.io/hashicorp/local",
+          "schema_version": 0,
+          "values": {
+            "content": "foobar",
+            "content_base64": null,
+            "content_base64sha256": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=",
+            "content_base64sha512": "ClAmHr0aOQ/tK/Mm8mc8FFWCpjQtUjIElz0CGTN/gWFqgGmwElh89WNfaSXxtWw2AjDBmyc1AO4BPgMGAb8kJQ==",
+            "content_md5": "3858f62230ac3c915f300c664312c63f",
+            "content_sha1": "8843d7f92416211de9ebb963ff4ce28125932878",
+            "content_sha256": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+            "content_sha512": "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "../test-move.txt",
+            "id": "8843d7f92416211de9ebb963ff4ce28125932878",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_values": {
+            "sensitive_content": true
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "local_file.after",
+      "previous_address": "local_file.before",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "after",
+      "provider_name": "registry.terraform.io/hashicorp/local",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "content": "foobar",
+          "content_base64": null,
+          "content_base64sha256": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=",
+          "content_base64sha512": "ClAmHr0aOQ/tK/Mm8mc8FFWCpjQtUjIElz0CGTN/gWFqgGmwElh89WNfaSXxtWw2AjDBmyc1AO4BPgMGAb8kJQ==",
+          "content_md5": "3858f62230ac3c915f300c664312c63f",
+          "content_sha1": "8843d7f92416211de9ebb963ff4ce28125932878",
+          "content_sha256": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+          "content_sha512": "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425",
+          "directory_permission": "0777",
+          "file_permission": "0777",
+          "filename": "../test-move.txt",
+          "id": "8843d7f92416211de9ebb963ff4ce28125932878",
+          "sensitive_content": null,
+          "source": null
+        },
+        "after": {
+          "content": "foobar",
+          "content_base64": null,
+          "content_base64sha256": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=",
+          "content_base64sha512": "ClAmHr0aOQ/tK/Mm8mc8FFWCpjQtUjIElz0CGTN/gWFqgGmwElh89WNfaSXxtWw2AjDBmyc1AO4BPgMGAb8kJQ==",
+          "content_md5": "3858f62230ac3c915f300c664312c63f",
+          "content_sha1": "8843d7f92416211de9ebb963ff4ce28125932878",
+          "content_sha256": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+          "content_sha512": "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425",
+          "directory_permission": "0777",
+          "file_permission": "0777",
+          "filename": "../test-move.txt",
+          "id": "8843d7f92416211de9ebb963ff4ce28125932878",
+          "sensitive_content": null,
+          "source": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "sensitive_content": true
+        },
+        "after_sensitive": {
+          "sensitive_content": true
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.13.5",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "local_file.after",
+            "mode": "managed",
+            "type": "local_file",
+            "name": "after",
+            "provider_name": "registry.terraform.io/hashicorp/local",
+            "schema_version": 0,
+            "values": {
+              "content": "foobar",
+              "content_base64": null,
+              "content_base64sha256": "w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=",
+              "content_base64sha512": "ClAmHr0aOQ/tK/Mm8mc8FFWCpjQtUjIElz0CGTN/gWFqgGmwElh89WNfaSXxtWw2AjDBmyc1AO4BPgMGAb8kJQ==",
+              "content_md5": "3858f62230ac3c915f300c664312c63f",
+              "content_sha1": "8843d7f92416211de9ebb963ff4ce28125932878",
+              "content_sha256": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+              "content_sha512": "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425",
+              "directory_permission": "0777",
+              "file_permission": "0777",
+              "filename": "../test-move.txt",
+              "id": "8843d7f92416211de9ebb963ff4ce28125932878",
+              "sensitive_content": null,
+              "source": null
+            },
+            "sensitive_values": {
+              "sensitive_content": true
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "local": {
+        "name": "local",
+        "full_name": "registry.terraform.io/hashicorp/local"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "local_file.after",
+          "mode": "managed",
+          "type": "local_file",
+          "name": "after",
+          "provider_config_key": "local",
+          "expressions": {
+            "content": {
+              "constant_value": "foobar"
+            },
+            "filename": {
+              "constant_value": "../test-move.txt"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/tests/fixtures/move/1-move/plan.txt
+++ b/tests/fixtures/move/1-move/plan.txt
@@ -1,0 +1,10 @@
+
+Terraform will perform the following actions:
+
+  # local_file.before has moved to local_file.after
+    resource "local_file" "after" {
+        id                   = "8843d7f92416211de9ebb963ff4ce28125932878"
+        # (10 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.

--- a/tests/fixtures/move/1-move/rendered.md
+++ b/tests/fixtures/move/1-move/rendered.md
@@ -1,0 +1,7 @@
+## 📝 Terraform Plan
+
+**→ Resource Changes: 0 to create, 0 to update, 0 to re-create, 0 to delete, 0 ephemeral. State Changes: 0 to import, 1 to move, 0 to remove from state.**
+
+### 🧭 Move
+
+- `local_file.before` → `local_file.after`

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
-import { renderPlan } from '../src/render'
+import { internalRenderPlan, planIsEmpty, plansAreEmpty, renderPlan } from '../src/render'
+import { parsePlanfileJSON } from '../src/planfile'
 import { getExecOutput } from '@actions/exec'
 
 jest.mock('@actions/exec')
@@ -53,4 +54,78 @@ test.each(['basic/6-terragrunt-multiplan'])('render terragrunt successful', asyn
   expect(getExecOutput).toHaveBeenCalledTimes(3)
   // expects 1 plans after execution
   expect(plans).toHaveLength(3)
+})
+
+describe('planIsEmpty', () => {
+  test('a plan without any changes is empty', () => {
+    expect(planIsEmpty({})).toBe(true)
+  })
+
+  test.each([
+    ['imports', { importedResources: ['terraform_data.a'] }],
+    ['moves', { movedResources: { 'local_file.b': 'local_file.a' } }],
+    ['removes from state', { forgottenResources: ['local_file.a'] }]
+  ])('a plan that only %s is not empty', (_name, plan) => {
+    expect(planIsEmpty(plan)).toBe(false)
+  })
+
+  test('plans are not empty if any of them only changes state', () => {
+    expect(plansAreEmpty([{}, { movedResources: { 'local_file.b': 'local_file.a' } }])).toBe(false)
+  })
+})
+
+describe('internalRenderPlan state changes', () => {
+  // A resource can be imported, moved or forgotten *and* changed. These plans are awkward to
+  // produce with the fixture generator, so they are asserted against hand-built planfiles.
+  function render(resourceChanges: object[], humanReadablePlan = '') {
+    const planJson = JSON.parse(
+      JSON.stringify({ format_version: '1.2', resource_changes: resourceChanges })
+    )
+    return internalRenderPlan(parsePlanfileJSON(planJson), humanReadablePlan)
+  }
+
+  test('an import that also updates counts as both', () => {
+    const plan = render(
+      [
+        {
+          address: 'local_file.a',
+          change: { actions: ['update'], importing: { id: 'abc' } }
+        }
+      ],
+      '  # local_file.a will be updated in-place\n  ~ resource "local_file" "a" {\n      x = 1\n    }\n'
+    )
+    expect(plan.importedResources).toEqual(['local_file.a'])
+    expect(Object.keys(plan.updatedResources ?? {})).toEqual(['local_file.a'])
+  })
+
+  test('a move that also deletes counts as both', () => {
+    const plan = render(
+      [
+        {
+          address: 'local_file.b',
+          previous_address: 'local_file.a',
+          change: { actions: ['delete'] }
+        }
+      ],
+      '  # local_file.b will be destroyed\n  - resource "local_file" "b" {\n      x = 1\n    }\n'
+    )
+    expect(plan.movedResources).toEqual({ 'local_file.b': 'local_file.a' })
+    expect(Object.keys(plan.deletedResources ?? {})).toEqual(['local_file.b'])
+  })
+
+  test('a create-then-forget resource counts as both created and removed from state', () => {
+    const plan = render(
+      [{ address: 'local_file.a', change: { actions: ['create', 'forget'] } }],
+      '  # local_file.a will be created\n  + resource "local_file" "a" {\n      x = 1\n    }\n'
+    )
+    expect(plan.forgottenResources).toEqual(['local_file.a'])
+    expect(Object.keys(plan.createdResources ?? {})).toEqual(['local_file.a'])
+  })
+
+  test('a plan with no state changes leaves the state fields undefined', () => {
+    const plan = render([{ address: 'local_file.a', change: { actions: ['no-op'] } }])
+    expect(plan.importedResources).toBeUndefined()
+    expect(plan.movedResources).toBeUndefined()
+    expect(plan.forgottenResources).toBeUndefined()
+  })
 })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -113,13 +113,64 @@ describe('internalRenderPlan state changes', () => {
     expect(Object.keys(plan.deletedResources ?? {})).toEqual(['local_file.b'])
   })
 
+  // Terraform renders `create`-then-`forget` with the ` +/.` action symbol and, unlike most
+  // actions, a single-space `#` comment.
+  const createThenForgetPlan = [
+    ' # local_file.a must be replaced, but the existing object will not be destroyed',
+    ' # (destroy = false is set in the configuration)',
+    ' +/. resource "local_file" "a" {',
+    '      ~ filename = "./a.txt" -> "./b.txt" # forces replacement',
+    '      ~ id       = "8843d7f92416211de9ebb963ff4ce28125932878" -> (known after apply)',
+    '    }',
+    ''
+  ].join('\n')
+
   test('a create-then-forget resource counts as both created and removed from state', () => {
     const plan = render(
       [{ address: 'local_file.a', change: { actions: ['create', 'forget'] } }],
-      '  # local_file.a will be created\n  + resource "local_file" "a" {\n      x = 1\n    }\n'
+      createThenForgetPlan
     )
     expect(plan.forgottenResources).toEqual(['local_file.a'])
     expect(Object.keys(plan.createdResources ?? {})).toEqual(['local_file.a'])
+    expect(plan.createdResources?.['local_file.a']).toContain(
+      '! filename = "./a.txt" -> "./b.txt" # forces replacement'
+    )
+  })
+
+  test('a resource is not extracted from the block of a longer address', () => {
+    const plan = render(
+      [{ address: 'local_file.a', change: { actions: ['create'] } }],
+      [
+        ' # local_file.ab will no longer be managed by Terraform, but will not be destroyed',
+        ' # (destroy = false is set in the configuration)',
+        ' . resource "local_file" "ab" {',
+        '        id = "forgotten"',
+        '    }',
+        '',
+        '  # local_file.a will be created',
+        '  + resource "local_file" "a" {',
+        '      + id = "created"',
+        '    }',
+        ''
+      ].join('\n')
+    )
+    expect(plan.createdResources?.['local_file.a']).toContain('+ id = "created"')
+    expect(plan.createdResources?.['local_file.a']).not.toContain('forgotten')
+  })
+
+  test('a reason mentioning a resource is not mistaken for the resource block', () => {
+    const plan = render(
+      [{ address: 'local_file.a', change: { actions: ['delete'] } }],
+      [
+        '  # local_file.a will be destroyed',
+        '  # (because the parent resource is being destroyed)',
+        '  - resource "local_file" "a" {',
+        '      - id = "gone"',
+        '    }',
+        ''
+      ].join('\n')
+    )
+    expect(plan.deletedResources?.['local_file.a']).toContain('```diff\n- id = "gone"\n```')
   })
 
   test('a plan with no state changes leaves the state fields undefined', () => {


### PR DESCRIPTION
The action was not producing output for plans that just had `imports`,
`moved` or `remove` blocks. Importing elements to bring something into IaC with
an initial PR that tries to not generate drift is a somewhat common practice and
it was missed by the plan.

I think this fixes #32.

* `planIsEmpty` now also considers imports, moves and removals from state
* `previous_address` added to the planfile schema
* New `📥 Import`, `🧭 Move` and `📤 Remove From State` sections listing the
  affected addresses
* New `num-resources-moved` and `num-resources-forgotten` outputs
* `["create","forget"]` now counts as a create as well as a removal from state;
  previously it was in no category at all
* New `import/` and `move/` fixtures; `3-remove`'s expectation corrected

**Maybe breaking?** `change-summary` is now two sentences, `Resource Changes: ...` and
`State Changes: ...`. State operations are different from resource actions.
Terraform can import, move or forge the same resource it also creates or
destroys, so keeping them in one sentenc implied a total that must not be added.

Happy to append to the existing sentence instead if you'd prefer to preserve the
format.
